### PR TITLE
Add supported method to get leverage

### DIFF
--- a/fixture/vcr_cassettes/futures/account/get_account_info_success.json
+++ b/fixture/vcr_cassettes/futures/account/get_account_info_success.json
@@ -1,0 +1,35 @@
+[
+  {
+    "request": {
+      "body": "{\"symbol\":\"BTC\"}",
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "https://api.hbdm.com/api/v1/contract_account_info?AccessKeyId=3c8dd81a-d8b5e97e-qv2d5ctgbn-9bd14&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2020-03-05T07%3A52%3A12&Signature=yH8cNA1KR1FeE91rmE/+ZLwPoAs5TkoolMzwYj+CN9U="
+    },
+    "response": {
+      "binary": false,
+      "body": "{\"status\":\"error\",\"err_code\":403,\"err_msg\":\"Verification failure [校验失败]\",\"ts\":1583394733097}",
+      "headers": {
+        "Date": "Thu, 05 Mar 2020 07:52:13 GMT",
+        "Content-Type": "text/plain;charset=UTF-8",
+        "Content-Length": "100",
+        "Connection": "keep-alive",
+        "Set-Cookie": "__cfduid=d0828182997896c1c12d9614f68de7dad1583394733; expires=Sat, 04-Apr-20 07:52:13 GMT; path=/; domain=.hbdm.com; HttpOnly; SameSite=Lax",
+        "Pragma": "no-cache",
+        "Cache-Control": "no-cache, no-store",
+        "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
+        "ReqId": "aa22f533466640c09dfbd2246abc999b",
+        "CF-Cache-Status": "DYNAMIC",
+        "Expect-CT": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
+        "Server": "cloudflare",
+        "CF-RAY": "56f2419969c1dd3a-SIN"
+      },
+      "status_code": 200,
+      "type": "ok"
+    }
+  }
+]

--- a/fixture/vcr_cassettes/futures/account/get_account_info_success.json
+++ b/fixture/vcr_cassettes/futures/account/get_account_info_success.json
@@ -8,25 +8,29 @@
       "method": "post",
       "options": [],
       "request_body": "",
-      "url": "https://api.hbdm.com/api/v1/contract_account_info?AccessKeyId=3c8dd81a-d8b5e97e-qv2d5ctgbn-9bd14&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2020-03-05T07%3A52%3A12&Signature=yH8cNA1KR1FeE91rmE/+ZLwPoAs5TkoolMzwYj+CN9U="
+      "url": "https://api.hbdm.com/api/v1/contract_account_info?AccessKeyId=3c8dd81a-d8b5e97e-qv2d5ctgbn-9bd14&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2020-03-05T09%3A09%3A29&Signature=A1UeDB3V0u8qn8fNqrQ/hceiBZMA7Q5toG0vHuuJzR0="
     },
     "response": {
       "binary": false,
-      "body": "{\"status\":\"error\",\"err_code\":403,\"err_msg\":\"Verification failure [校验失败]\",\"ts\":1583394733097}",
+      "body": "{\"status\":\"ok\",\"data\":[{\"symbol\":\"BTC\",\"margin_balance\":0.010000000000000000,\"margin_position\":0,\"margin_frozen\":0E-18,\"margin_available\":0.010000000000000000,\"profit_real\":0E-18,\"profit_unreal\":0,\"risk_rate\":null,\"withdraw_available\":0.010000000000000000,\"liquidation_price\":null,\"lever_rate\":20,\"adjust_factor\":0.150000000000000000,\"margin_static\":0.010000000000000000,\"is_debit\":0}],\"ts\":1583399370319}",
       "headers": {
-        "Date": "Thu, 05 Mar 2020 07:52:13 GMT",
+        "Date": "Thu, 05 Mar 2020 09:09:30 GMT",
         "Content-Type": "text/plain;charset=UTF-8",
-        "Content-Length": "100",
+        "Content-Length": "405",
         "Connection": "keep-alive",
-        "Set-Cookie": "__cfduid=d0828182997896c1c12d9614f68de7dad1583394733; expires=Sat, 04-Apr-20 07:52:13 GMT; path=/; domain=.hbdm.com; HttpOnly; SameSite=Lax",
+        "Set-Cookie": "__cfduid=d07a3256387890ea89a9fa25fc5e217d61583399370; expires=Sat, 04-Apr-20 09:09:30 GMT; path=/; domain=.hbdm.com; HttpOnly; SameSite=Lax",
         "Pragma": "no-cache",
         "Cache-Control": "no-cache, no-store",
         "Expires": "Thu, 01 Jan 1970 00:00:00 GMT",
-        "ReqId": "aa22f533466640c09dfbd2246abc999b",
+        "ReqId": "a2400100c4814c5c932c0862f12627ff",
+        "ratelimit-remaining": "9",
+        "ratelimit-reset": "1583399371318",
+        "ratelimit-interval": "1000",
+        "ratelimit-limit": "10",
         "CF-Cache-Status": "DYNAMIC",
         "Expect-CT": "max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
         "Server": "cloudflare",
-        "CF-RAY": "56f2419969c1dd3a-SIN"
+        "CF-RAY": "56f2b2d0296cc3b3-SIN"
       },
       "status_code": 200,
       "type": "ok"

--- a/lib/ex_huobi/futures/account_info.ex
+++ b/lib/ex_huobi/futures/account_info.ex
@@ -1,0 +1,20 @@
+defmodule ExHuobi.Futures.AccountInfo do
+  @type t :: %__MODULE__{}
+
+  defstruct ~w(
+    adjust_factor
+    is_debit
+    lever_rate
+    liquidation_price
+    margin_available
+    margin_balance
+    margin_frozen
+    margin_position
+    margin_static
+    profit_real
+    profit_unreal
+    risk_rate
+    symbol
+    withdraw_available
+  )a
+end

--- a/lib/ex_huobi/futures/rest/account.ex
+++ b/lib/ex_huobi/futures/rest/account.ex
@@ -1,6 +1,8 @@
 defmodule ExHuobi.Futures.Rest.Account do
   alias ExHuobi.Rest.HTTPClient
   alias ExHuobi.Futures.Rest.Handler
+  alias ExHuobi.Util
+  alias ExHuobi.Futures.AccountInfo
 
   @type config :: ExHuobi.Config.t()
   @type position :: map
@@ -16,5 +18,20 @@ defmodule ExHuobi.Futures.Rest.Account do
       config
     )
     |> Handler.parse_response()
+  end
+
+  @spec get_account_info(String.t(), ExHuobi.Config.t()) :: {:error, any} | {:ok, any}
+  def get_account_info(instrument_id, config) do
+    HTTPClient.post(
+      @hbdm_host,
+      "/api/v1/contract_account_info",
+      %{"symbol" => instrument_id},
+      config
+    )
+    |> Handler.parse_response()
+    |> case do
+      {:ok, data} -> Util.parse_to_struct(data, AccountInfo)
+      {:error, _} = error -> error
+    end
   end
 end

--- a/lib/ex_huobi/futures/rest/account.ex
+++ b/lib/ex_huobi/futures/rest/account.ex
@@ -29,9 +29,6 @@ defmodule ExHuobi.Futures.Rest.Account do
       config
     )
     |> Handler.parse_response()
-    |> case do
-      {:ok, data} -> Util.parse_to_struct(data, AccountInfo)
-      {:error, _} = error -> error
-    end
+    |> Util.transform_response_data(AccountInfo)
   end
 end

--- a/lib/ex_huobi/futures/rest/account.ex
+++ b/lib/ex_huobi/futures/rest/account.ex
@@ -11,8 +11,8 @@ defmodule ExHuobi.Futures.Rest.Account do
 
   @spec get_position(String.t(), config) :: {:error, any} | {:ok, any}
   def get_position(instrument_id, config) do
-    HTTPClient.post(
-      @hbdm_host,
+    @hbdm_host
+    |> HTTPClient.post(
       "/api/v1/contract_position_info",
       %{"symbol" => instrument_id},
       config
@@ -22,8 +22,8 @@ defmodule ExHuobi.Futures.Rest.Account do
 
   @spec get_account_info(String.t(), ExHuobi.Config.t()) :: {:error, any} | {:ok, any}
   def get_account_info(instrument_id, config) do
+    @hbdm_host
     HTTPClient.post(
-      @hbdm_host,
       "/api/v1/contract_account_info",
       %{"symbol" => instrument_id},
       config

--- a/lib/ex_huobi/futures/rest/account.ex
+++ b/lib/ex_huobi/futures/rest/account.ex
@@ -23,7 +23,7 @@ defmodule ExHuobi.Futures.Rest.Account do
   @spec get_account_info(String.t(), ExHuobi.Config.t()) :: {:error, any} | {:ok, any}
   def get_account_info(instrument_id, config) do
     @hbdm_host
-    HTTPClient.post(
+    |> HTTPClient.post(
       "/api/v1/contract_account_info",
       %{"symbol" => instrument_id},
       config

--- a/lib/ex_huobi/futures/rest/handler.ex
+++ b/lib/ex_huobi/futures/rest/handler.ex
@@ -1,6 +1,9 @@
 defmodule ExHuobi.Futures.Rest.Handler do
+  @moduledoc false
+
   @spec parse_response({:error, HTTPoison.Error.t()} | {:ok, HTTPoison.Response.t()}) ::
           {:error, any} | {:ok, any}
+  @doc false
   def parse_response(response) do
     case response do
       {:ok, %HTTPoison.Response{body: body, status_code: status_code}} ->

--- a/lib/ex_huobi/futures/rest/handler.ex
+++ b/lib/ex_huobi/futures/rest/handler.ex
@@ -22,7 +22,7 @@ defmodule ExHuobi.Futures.Rest.Handler do
       end
     else
       case Jason.decode(body) do
-        {:ok, json} -> {:ok, json, status_code}
+        {:ok, json} -> {:error, json, status_code}
         {:error, _} -> {:error, body, status_code}
       end
     end

--- a/lib/ex_huobi/futures/rest/order.ex
+++ b/lib/ex_huobi/futures/rest/order.ex
@@ -72,10 +72,10 @@ defmodule ExHuobi.Futures.Rest.Order do
 
   # ## Examples
 
-  # iex> ExHuobi.Futures.Private.cancel_order({
-  #   "order_id : "1234",
-  #   "symbol": "BTC"
-  # })
+  # iex> ExHuobi.Futures.Private.cancel_order(%{
+  #   "order_id => "1234",
+  #   "symbol" => "BTC"
+  # }, config)
   # """
   @spec cancel_order(map, config) :: {:ok, any} | {:error, any}
   def cancel_order(order, config) do

--- a/lib/ex_huobi/futures/rest/order.ex
+++ b/lib/ex_huobi/futures/rest/order.ex
@@ -27,7 +27,8 @@ defmodule ExHuobi.Futures.Rest.Order do
   # """
   @spec create_order(map, config) :: {:ok, map} | {:error, any}
   def create_order(order, config) do
-    HTTPClient.post(@hbdm_host, "/api/v1/contract_order", order, config)
+    @hbdm_host
+    |> HTTPClient.post("/api/v1/contract_order", order, config)
     |> Handler.parse_response()
   end
 
@@ -61,7 +62,8 @@ defmodule ExHuobi.Futures.Rest.Order do
   # """
   @spec create_bulk_orders(list(map), config) :: {:ok, list} | {:error, any}
   def create_bulk_orders(orders, config) do
-    HTTPClient.post(@hbdm_host, "/api/v1/contract_order", orders, config)
+    @hbdm_host
+    |> HTTPClient.post("/api/v1/contract_order", orders, config)
     |> Handler.parse_response()
   end
 
@@ -79,7 +81,8 @@ defmodule ExHuobi.Futures.Rest.Order do
   # """
   @spec cancel_order(map, config) :: {:ok, any} | {:error, any}
   def cancel_order(order, config) do
-    HTTPClient.post(@hbdm_host, "/api/v1/contract_cancel", order, config)
+    @hbdm_host
+    |> HTTPClient.post("/api/v1/contract_cancel", order, config)
     |> Handler.parse_response()
   end
 end

--- a/lib/ex_huobi/margin/rest/account.ex
+++ b/lib/ex_huobi/margin/rest/account.ex
@@ -1,6 +1,6 @@
 defmodule ExHuobi.Margin.Rest.Account do
   alias ExHuobi.Rest.HTTPClient
-  alias ExHuobi.Margin.Account
+  alias ExHuobi.Margin.Account, as: AccountModel
   alias ExHuobi.Margin.Rest.Handler
   alias ExHuobi.Util
 
@@ -18,6 +18,8 @@ defmodule ExHuobi.Margin.Rest.Account do
   def get(config) do
     HTTPClient.get(@margin_endpoint, "/v1/account/accounts", config)
     |> Handler.parse_response()
-    |> Util.transform_response_data(Account)
+    |> Util.transform_response_data(AccountModel)
   end
+
+
 end

--- a/lib/ex_huobi/margin/rest/account.ex
+++ b/lib/ex_huobi/margin/rest/account.ex
@@ -16,10 +16,9 @@ defmodule ExHuobi.Margin.Rest.Account do
 
   @spec get(config) :: response
   def get(config) do
-    HTTPClient.get(@margin_endpoint, "/v1/account/accounts", config)
+    @margin_endpoint
+    |> HTTPClient.get("/v1/account/accounts", config)
     |> Handler.parse_response()
     |> Util.transform_response_data(AccountModel)
   end
-
-
 end

--- a/lib/ex_huobi/margin/rest/account.ex
+++ b/lib/ex_huobi/margin/rest/account.ex
@@ -2,6 +2,7 @@ defmodule ExHuobi.Margin.Rest.Account do
   alias ExHuobi.Rest.HTTPClient
   alias ExHuobi.Margin.Account
   alias ExHuobi.Margin.Rest.Handler
+  alias ExHuobi.Util
 
   @margin_endpoint "https://api.huobi.pro"
 
@@ -15,33 +16,8 @@ defmodule ExHuobi.Margin.Rest.Account do
 
   @spec get(config) :: response
   def get(config) do
-    case HTTPClient.get(@margin_endpoint, "/v1/account/accounts", config)
-         |> Handler.parse_response() do
-      {:ok, data} ->
-        {:ok, data |> parse_to_obj()}
-
-      {:error, error} ->
-        {:error, error}
-    end
-  end
-
-  defp parse_to_obj(data) when is_list(data) do
-    data
-    |> Enum.map(&to_struct/1)
-  end
-
-  defp parse_to_obj(data) when is_map(data) do
-    data |> to_struct
-  end
-
-  defp to_struct(data) do
-    {:ok, obj} =
-      data
-      |> Mapail.map_to_struct(
-        Account,
-        transformations: [:snake_case]
-      )
-
-    obj
+    HTTPClient.get(@margin_endpoint, "/v1/account/accounts", config)
+    |> Handler.parse_response()
+    |> Util.transform_response_data(Account)
   end
 end

--- a/lib/ex_huobi/margin/rest/order.ex
+++ b/lib/ex_huobi/margin/rest/order.ex
@@ -18,7 +18,8 @@ defmodule ExHuobi.Margin.Rest.Order do
 
   @spec get(order_id, config) :: response
   def get(order_id, config) do
-    HTTPClient.get(@margin_endpoint, "/v1/order/orders/#{order_id}", config)
+    @margin_endpoint
+    |> HTTPClient.get("/v1/order/orders/#{order_id}", config)
     |> Handler.parse_response()
     |> Util.transform_response_data(Order)
   end
@@ -31,7 +32,8 @@ defmodule ExHuobi.Margin.Rest.Order do
   """
   @spec get_open(params, config) :: response
   def get_open(params, config) do
-    HTTPClient.get(@margin_endpoint, "/v1/order/openOrders", params, config)
+    @margin_endpoint
+    |> HTTPClient.get("/v1/order/openOrders", params, config)
     |> Handler.parse_response()
     |> Util.transform_response_data(Order)
   end
@@ -53,7 +55,8 @@ defmodule ExHuobi.Margin.Rest.Order do
   """
   @spec create(params, config) :: response
   def create(params, config) do
-    HTTPClient.post(@margin_endpoint, "/v1/order/orders/place", params, config)
+    @margin_endpoint
+    |> HTTPClient.post("/v1/order/orders/place", params, config)
     |> Handler.parse_response()
   end
 
@@ -68,7 +71,8 @@ defmodule ExHuobi.Margin.Rest.Order do
   """
   @spec bulk_create(params, config) :: response
   def bulk_create(params, config) do
-    HTTPClient.post(@margin_endpoint, "/v1/order/batch-orders", params, config)
+    @margin_endpoint
+    |> HTTPClient.post("/v1/order/batch-orders", params, config)
     |> Handler.parse_response()
   end
 
@@ -80,8 +84,8 @@ defmodule ExHuobi.Margin.Rest.Order do
   """
   @spec cancel(order_id, config) :: response
   def cancel(order_id, config) do
-    HTTPClient.post(
-      @margin_endpoint,
+    @margin_endpoint
+    |> HTTPClient.post(
       "/v1/order/orders/#{order_id}/submitcancel",
       %{},
       config
@@ -97,7 +101,8 @@ defmodule ExHuobi.Margin.Rest.Order do
   """
   @spec bulk_cancel(params, config) :: response
   def bulk_cancel(params, config) do
-    HTTPClient.post(@margin_endpoint, "/v1/order/orders/batchcancel", params, config)
+    @margin_endpoint
+    |> HTTPClient.post("/v1/order/orders/batchcancel", params, config)
     |> Handler.parse_response()
   end
 end

--- a/lib/ex_huobi/margin/rest/order.ex
+++ b/lib/ex_huobi/margin/rest/order.ex
@@ -16,8 +16,8 @@ defmodule ExHuobi.Margin.Rest.Order do
           | {:error, {:config_missing, String.t()}}
   @type response :: success_response | failure_response
 
-  @spec get_order(order_id, config) :: response
-  def get_order(order_id, config) do
+  @spec get(order_id, config) :: response
+  def get(order_id, config) do
     HTTPClient.get(@margin_endpoint, "/v1/order/orders/#{order_id}", config)
     |> Handler.parse_response()
     |> Util.transform_response_data(Order)
@@ -29,8 +29,8 @@ defmodule ExHuobi.Margin.Rest.Order do
 
     iex> ExHuobi.Margin.Rest.Order.get_open(%{"account-id": 12035991, symbol: "btcusdt"}, config)
   """
-  @spec get_open_order(params, config) :: response
-  def get_open_order(params, config) do
+  @spec get_open(params, config) :: response
+  def get_open(params, config) do
     HTTPClient.get(@margin_endpoint, "/v1/order/openOrders", params, config)
     |> Handler.parse_response()
     |> Util.transform_response_data(Order)

--- a/lib/ex_huobi/margin/rest/order.ex
+++ b/lib/ex_huobi/margin/rest/order.ex
@@ -67,17 +67,14 @@ defmodule ExHuobi.Margin.Rest.Order do
   def bulk_create(params, config) do
     case HTTPClient.post(@margin_endpoint, "/v1/order/batch-orders", params, config)
          |> Handler.parse_response() do
-      {:ok, data} ->
-        {:ok, data |> add_id() |> parse_to_obj()}
-
-      {:error, _} = error ->
-        error
+      {:ok, data} -> {:ok, data}
+      {:error, _} = error -> error
     end
   end
 
-  defp add_id(data) do
-    data |> Enum.map(fn el -> Map.put(el, "id", el["order-id"]) end)
-  end
+  # defp add_id(data) do
+  #   data |> Enum.map(fn el -> Map.put(el, "id", el["order-id"]) end)
+  # end
 
   @doc """
   Get open orders.

--- a/lib/ex_huobi/util.ex
+++ b/lib/ex_huobi/util.ex
@@ -105,4 +105,31 @@ defmodule ExHuobi.Util do
       "Timestamp" => time
     }
   end
+
+  def transform_response_data(response, module) do
+    case response do
+      {:ok, data} -> {:ok, data |> parse_to_struct(module)}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp parse_to_struct(data, module) when is_list(data) do
+    data
+    |> Enum.map(&to_struct(&1, module))
+  end
+
+  defp parse_to_struct(data, module) when is_map(data) do
+    data |> to_struct(module)
+  end
+
+  defp to_struct(data, module) do
+    {:ok, obj} =
+      data
+      |> Mapail.map_to_struct(
+        module,
+        transformations: [:snake_case]
+      )
+
+    obj
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExHuobi.MixProject do
   def project do
     [
       app: :ex_huobi,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/test/futures/rest/account_test.exs
+++ b/test/futures/rest/account_test.exs
@@ -14,6 +14,40 @@ defmodule ExHuobi.Futures.Rest.Account.Test do
     HTTPoison.start()
   end
 
+  test "do somethign here" do
+    response = [
+      %{
+        "adjust_factor" => 0.15,
+        "is_debit" => 0,
+        "lever_rate" => 20,
+        "liquidation_price" => nil,
+        "margin_available" => 0.01,
+        "margin_balance" => 0.01,
+        "margin_frozen" => 0.0,
+        "margin_position" => 0,
+        "margin_static" => 0.01,
+        "profit_real" => 0.0,
+        "profit_unreal" => 0,
+        "risk_rate" => nil,
+        "symbol" => "BTC",
+        "withdraw_available" => 0.01
+      }
+    ]
+
+    Jason.encode(response) |> IO.inspect()
+  end
+
+  test "should return account information with leverage" do
+    use_cassette("/futures/account/get_account_info_success") do
+      config = %ExHuobi.Config{
+        api_key: "3c8dd81a-d8b5e97e-qv2d5ctgbn-9bd14",
+        api_secret: "94472b76-30a703ac-e75d7396-c34a0"
+      }
+
+      ExHuobi.Futures.Rest.Account.get_account_info("BTC", config) |> IO.inspect()
+    end
+  end
+
   test "should return position" do
     use_cassette("/futures/account/get_position_success") do
       assert ExHuobi.Futures.Rest.Account.get_position("BTC", @config) ==

--- a/test/futures/rest/account_test.exs
+++ b/test/futures/rest/account_test.exs
@@ -3,11 +3,6 @@ defmodule ExHuobi.Futures.Rest.Account.Test do
 
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
-  # @config %ExHuobi.Config{
-  #   api_key: System.get_env("HUOBI_API_KEY"),
-  #   api_secret: System.get_env("HUOBI_API_SECRET")
-  # }
-
   setup_all do
     HTTPoison.start()
 

--- a/test/futures/rest/account_test.exs
+++ b/test/futures/rest/account_test.exs
@@ -3,54 +3,50 @@ defmodule ExHuobi.Futures.Rest.Account.Test do
 
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
-  @config %ExHuobi.Config{
-    api_key: System.get_env("HUOBI_API_KEY"),
-    api_secret: System.get_env("HUOBI_API_SECRET")
-  }
+  # @config %ExHuobi.Config{
+  #   api_key: System.get_env("HUOBI_API_KEY"),
+  #   api_secret: System.get_env("HUOBI_API_SECRET")
+  # }
 
   setup_all do
-    System.put_env("HUOBI_API_KEY", "12343")
-    System.put_env("HUOBI_API_SECRET", "12345")
     HTTPoison.start()
-  end
 
-  test "do somethign here" do
-    response = [
-      %{
-        "adjust_factor" => 0.15,
-        "is_debit" => 0,
-        "lever_rate" => 20,
-        "liquidation_price" => nil,
-        "margin_available" => 0.01,
-        "margin_balance" => 0.01,
-        "margin_frozen" => 0.0,
-        "margin_position" => 0,
-        "margin_static" => 0.01,
-        "profit_real" => 0.0,
-        "profit_unreal" => 0,
-        "risk_rate" => nil,
-        "symbol" => "BTC",
-        "withdraw_available" => 0.01
+    %{
+      config: %ExHuobi.Config{
+        api_key: "12345",
+        api_secret: "12345"
       }
-    ]
-
-    Jason.encode(response) |> IO.inspect()
+    }
   end
 
-  test "should return account information with leverage" do
+  test "should return account information with leverage", %{config: config} do
     use_cassette("/futures/account/get_account_info_success") do
-      config = %ExHuobi.Config{
-        api_key: "3c8dd81a-d8b5e97e-qv2d5ctgbn-9bd14",
-        api_secret: "94472b76-30a703ac-e75d7396-c34a0"
-      }
-
-      ExHuobi.Futures.Rest.Account.get_account_info("BTC", config) |> IO.inspect()
+      assert ExHuobi.Futures.Rest.Account.get_account_info("BTC", config) ==
+               {:ok,
+                [
+                  %ExHuobi.Futures.AccountInfo{
+                    adjust_factor: 0.15,
+                    is_debit: 0,
+                    lever_rate: 20,
+                    liquidation_price: nil,
+                    margin_available: 0.01,
+                    margin_balance: 0.01,
+                    margin_frozen: 0.0,
+                    margin_position: 0,
+                    margin_static: 0.01,
+                    profit_real: 0.0,
+                    profit_unreal: 0,
+                    risk_rate: nil,
+                    symbol: "BTC",
+                    withdraw_available: 0.01
+                  }
+                ]}
     end
   end
 
-  test "should return position" do
+  test "should return position", %{config: config} do
     use_cassette("/futures/account/get_position_success") do
-      assert ExHuobi.Futures.Rest.Account.get_position("BTC", @config) ==
+      assert ExHuobi.Futures.Rest.Account.get_position("BTC", config) ==
                {:ok,
                 [
                   %{
@@ -74,9 +70,9 @@ defmodule ExHuobi.Futures.Rest.Account.Test do
     end
   end
 
-  test "should return error when have problem" do
+  test "should return error when have problem", %{config: config} do
     use_cassette("/futures/account/get_position_error") do
-      assert ExHuobi.Futures.Rest.Account.get_position("BTC", @config) ==
+      assert ExHuobi.Futures.Rest.Account.get_position("BTC", config) ==
                {:error,
                 %{
                   "err_code" => 403,

--- a/test/futures/rest/order_test.exs
+++ b/test/futures/rest/order_test.exs
@@ -3,18 +3,18 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
 
   use ExVCR.Mock, adapter: ExVCR.Adapter.Hackney
 
-  @config %ExHuobi.Config{
-    api_key: System.get_env("HUOBI_API_KEY"),
-    api_secret: System.get_env("HUOBI_API_SECRET")
-  }
-
   setup_all do
-    System.put_env("HUOBI_API_KEY", "12343")
-    System.put_env("HUOBI_API_SECRET", "12345")
     HTTPoison.start()
+
+    %{
+      config: %ExHuobi.Config{
+        api_key: "12345",
+        api_secret: "12345"
+      }
+    }
   end
 
-  test "create order success" do
+  test "create order success", %{config: config} do
     use_cassette("/futures/order/create_order_success") do
       order = %{
         "contract_type" => "this_week",
@@ -27,13 +27,13 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
         "volume" => 1
       }
 
-      assert ExHuobi.Futures.Rest.Order.create_order(order, @config) ==
+      assert ExHuobi.Futures.Rest.Order.create_order(order, config) ==
                {:ok,
                 %{"order_id" => 680_494_320_326_811_648, "order_id_str" => "680494320326811648"}}
     end
   end
 
-  test "create order invalid key error" do
+  test "create order invalid key error", %{config: config} do
     use_cassette("/futures/order/create_order_invalid_key_error") do
       order = %{
         "contract_type" => "this_week",
@@ -51,7 +51,7 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
          "err_code" => error_code,
          "err_msg" => err_msg,
          "status" => status
-       }} = ExHuobi.Futures.Rest.Order.create_order(order, @config)
+       }} = ExHuobi.Futures.Rest.Order.create_order(order, config)
 
       assert error_code == 403
       assert String.starts_with?(err_msg, "Incorrect Access key") == true
@@ -59,7 +59,7 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
     end
   end
 
-  test "create order verification error" do
+  test "create order verification error", %{config: config} do
     use_cassette("/futures/order/create_order_vf_error") do
       order = nil
 
@@ -68,7 +68,7 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
          "err_code" => error_code,
          "err_msg" => err_msg,
          "status" => status
-       }} = ExHuobi.Futures.Rest.Order.create_order(order, @config)
+       }} = ExHuobi.Futures.Rest.Order.create_order(order, config)
 
       assert error_code == 403
       assert String.starts_with?(err_msg, "Verification failure") == true
@@ -76,7 +76,7 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
     end
   end
 
-  test "create order abnormal service error" do
+  test "create order abnormal service error", %{config: config} do
     use_cassette("/futures/order/create_order_abnormal_service_error") do
       order = nil
 
@@ -85,7 +85,7 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
          "err_code" => error_code,
          "err_msg" => err_msg,
          "status" => status
-       }} = ExHuobi.Futures.Rest.Order.create_order(order, @config)
+       }} = ExHuobi.Futures.Rest.Order.create_order(order, config)
 
       assert error_code == 1030
       assert String.starts_with?(err_msg, "Abnormal service.") == true
@@ -93,7 +93,7 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
     end
   end
 
-  test "create order insufficient margin error" do
+  test "create order insufficient margin error", %{config: config} do
     use_cassette("/futures/order/create_order_insufficient_margin_error") do
       order = nil
 
@@ -102,7 +102,7 @@ defmodule ExHuobi.Futures.Rest.Order.Test do
          "err_code" => error_code,
          "err_msg" => err_msg,
          "status" => status
-       }} = ExHuobi.Futures.Rest.Order.create_order(order, @config)
+       }} = ExHuobi.Futures.Rest.Order.create_order(order, config)
 
       assert error_code == 1047
       assert String.starts_with?(err_msg, "Insufficient margin available.") == true

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -4,8 +4,8 @@ defmodule ExHuobi.Rest.HTTPClientTest do
   doctest ExHuobi.Rest.HTTPClient
 
   @config %ExHuobi.Config{
-    api_key: System.get_env("HUOBI_API_KEY"),
-    api_secret: System.get_env("HUOBI_API_SECRET")
+    api_key: "12345",
+    api_secret: "12345"
   }
 
   describe "test helper functions in http client" do

--- a/test/margin/rest/orders/cancel_test.exs
+++ b/test/margin/rest/orders/cancel_test.exs
@@ -6,27 +6,27 @@ defmodule ExHuobi.Rest.Orders.CancelTest do
 
   setup_all do
     HTTPoison.start()
-    :ok
+    %{
+      config: %ExHuobi.Config{
+        api_key: "12345",
+        api_secret: "12345"
+      }
+    }
   end
 
-  @config %ExHuobi.Config{
-    api_key: System.get_env("HUOBI_API_KEY"),
-    api_secret: System.get_env("HUOBI_API_SECRET")
-  }
-
-  test "cancel order" do
+  test "cancel order", %{config: config} do
     use_cassette "rest/orders/cancel", custom: true do
       cancel_id = "70662287304"
-      {:ok, order} = Rest.cancel(cancel_id, @config)
-      assert cancel_id == order.id
+      {:ok, order} = Rest.cancel(cancel_id, config)
+      assert cancel_id == order
     end
   end
 
-  test "cancel order batch" do
+  test "cancel order batch", %{config: config} do
     use_cassette "rest/orders/bulk_cancel", custom: true do
       params = %{"order-id": ["70664141188", "70664141185"]}
 
-      {:ok, data} = Rest.bulk_cancel(params, @config)
+      {:ok, data} = Rest.bulk_cancel(params, config)
       assert length(data["success"]) == 2
     end
   end

--- a/test/margin/rest/orders/create_test.exs
+++ b/test/margin/rest/orders/create_test.exs
@@ -6,15 +6,15 @@ defmodule ExHuobi.Rest.Orders.CreateTest do
 
   setup_all do
     HTTPoison.start()
-    :ok
+    %{
+      config: %ExHuobi.Config{
+        api_key: "12345",
+        api_secret: "12345"
+      }
+    }
   end
 
-  @config %ExHuobi.Config{
-    api_key: System.get_env("HUOBI_API_KEY"),
-    api_secret: System.get_env("HUOBI_API_SECRET")
-  }
-
-  test "create order" do
+  test "create order", %{config: config} do
     use_cassette "rest/orders/create", custom: true do
       return_id = "70646394808"
 
@@ -27,12 +27,12 @@ defmodule ExHuobi.Rest.Orders.CreateTest do
         source: "super-margin-api"
       }
 
-      {:ok, order} = Rest.create(params, @config)
-      assert return_id == order.id
+      {:ok, order} = Rest.create(params, config)
+      assert order == return_id
     end
   end
 
-  test "create order batch" do
+  test "create order batch", %{config: config} do
     use_cassette "rest/orders/bulk_create", custom: true do
       params = [
         %{
@@ -53,7 +53,7 @@ defmodule ExHuobi.Rest.Orders.CreateTest do
         }
       ]
 
-      {:ok, orders} = Rest.bulk_create(params, @config)
+      {:ok, orders} = Rest.bulk_create(params, config)
       assert length(orders) == 2
     end
   end

--- a/test/margin/rest/orders/get_test.exs
+++ b/test/margin/rest/orders/get_test.exs
@@ -7,27 +7,28 @@ defmodule ExHuobi.Rest.Orders.GetTest do
 
   setup_all do
     HTTPoison.start()
-    :ok
+
+    %{
+      config: %ExHuobi.Config{
+        api_key: "12345",
+        api_secret: "12345"
+      }
+    }
   end
 
-  @config %ExHuobi.Config{
-    api_key: System.get_env("HUOBI_API_KEY"),
-    api_secret: System.get_env("HUOBI_API_SECRET")
-  }
-
-  test "returns order by id" do
+  test "returns order by id", %{config: config} do
     use_cassette "rest/orders/get_by_id", custom: true do
       input_id = 70_646_394_808
-      {:ok, %Order{id: id}} = Rest.get(70_646_394_808, @config)
+      {:ok, %Order{id: id}} = Rest.get(70_646_394_808, config)
 
       assert input_id == id
     end
   end
 
-  test "returns all open orders" do
+  test "returns all open orders", %{config: config} do
     use_cassette "rest/orders/get_all_open", custom: true do
       assert {:ok, [%Order{}]} =
-               Rest.get_open(%{"account-id": 123_456_789, symbol: "btcusdt"}, @config)
+               Rest.get_open(%{"account-id": 123_456_789, symbol: "btcusdt"}, config)
     end
   end
 end


### PR DESCRIPTION
The purpose of the pull request :
- Change the response of method create/cancel for margin orders. Don't map to struct, but return raw data from api
- Remove lots of duplicate code in margin order/account and futures order/account
- Add new method to get account leverage.