### PR TITLE
Add APIs to get last traded price

### DIFF
--- a/lib/ex_huobi/futures/rest/public.ex
+++ b/lib/ex_huobi/futures/rest/public.ex
@@ -21,6 +21,13 @@ defmodule ExHuobi.Futures.Rest.Public do
     |> Handler.parse_response()
   end
 
+  def get_last_trade(instrument_id) do
+    instrument_id = String.downcase(instrument_id)
+
+    HTTPoison.get("#{@hbdm_host}/market/trade?symbol=#{instrument_id}")
+    |> Handler.parse_response()
+  end
+
   def get_market_depth(instrument) do
     HTTPoison.get("#{@hbdm_host}/market/depth?symbol=#{instrument}&type=step0")
     |> Handler.parse_response()

--- a/lib/ex_huobi/margin/rest/handler.ex
+++ b/lib/ex_huobi/margin/rest/handler.ex
@@ -11,6 +11,9 @@ defmodule ExHuobi.Margin.Rest.Handler do
       {:ok, %{"status" => "ok", "data" => data}} ->
         {:ok, data}
 
+      {:ok, %{"status" => "ok", "tick" => %{"data" => data}}} ->
+        {:ok, data}
+
       {:error, error} ->
         {:error, {:poison_decode_error, error}}
     end

--- a/lib/ex_huobi/margin/rest/public.ex
+++ b/lib/ex_huobi/margin/rest/public.ex
@@ -11,6 +11,13 @@ defmodule ExHuobi.Margin.Rest.Public do
     |> Handler.parse_response()
   end
 
+  def get_last_trade(instrument_id) do
+    instrument_id = String.downcase(instrument_id)
+
+    HTTPoison.get("#{@hbdm_host}/market/trade?symbol=#{instrument_id}")
+    |> Handler.parse_response()
+  end
+
   def instruments() do
     HTTPoison.get("#{@hbdm_host}/v1/common/symbols")
     |> Handler.parse_response()

--- a/lib/ex_huobi/swap/rest/public.ex
+++ b/lib/ex_huobi/swap/rest/public.ex
@@ -21,6 +21,13 @@ defmodule ExHuobi.Swap.Rest.Public do
     |> Handler.parse_response()
   end
 
+  def get_last_trade(instrument_id) do
+    instrument_id = String.downcase(instrument_id)
+
+    HTTPoison.get("#{@hbdm_host}/swap-ex/market/trade?contract_code=#{instrument_id}")
+    |> Handler.parse_response()
+  end
+
   def get_index_price(instrument_id) do
     HTTPoison.get("#{@hbdm_host}/swap-api/v1/swap_index?contract_code=#{instrument_id}")
     |> Handler.parse_response()

--- a/lib/ex_huobi/usdt_swap/rest/public.ex
+++ b/lib/ex_huobi/usdt_swap/rest/public.ex
@@ -27,6 +27,13 @@ defmodule ExHuobi.UsdtSwap.Rest.Public do
     |> Handler.parse_response()
   end
 
+  def get_last_trade(instrument_id) do
+    instrument_id = String.downcase(instrument_id)
+
+    HTTPoison.get("#{@hbdm_host}/linear-swap-ex/market/trade?contract_code=#{instrument_id}")
+    |> Handler.parse_response()
+  end
+
   def get_index_price(instrument_id) do
     HTTPoison.get("#{@hbdm_host}/linear-swap-api/v1/swap_index?contract_code=#{instrument_id}")
     |> Handler.parse_response()


### PR DESCRIPTION
Add APIs to get last traded price of Huobi's [Spot/Margin](https://huobiapi.github.io/docs/spot/v1/en/#get-the-last-trade), [Futures](https://huobiapi.github.io/docs/dm/v1/en/#query-the-last-trade-of-a-contract), [Coin-margined Swap](https://huobiapi.github.io/docs/coin_margined_swap/v1/en/#query-the-last-trade-of-a-contract),  [USDT-margined Swap](https://huobiapi.github.io/docs/usdt_swap/v1/en/#general-query-the-last-trade-of-a-contract).