### PR TITLE
Add account and position api

### DIFF
--- a/lib/ex_huobi/futures/position.ex
+++ b/lib/ex_huobi/futures/position.ex
@@ -1,0 +1,23 @@
+defmodule ExHuobi.Futures.Position do
+  @moduledoc false
+
+  @type t :: %__MODULE__{}
+
+  defstruct ~w(
+    symbol
+    contract_code
+    contract_type
+    volume
+    available
+    frozen
+    cost_open
+    cost_hold
+    profit_unreal
+    profit_rate
+    lever_rate
+    position_margin
+    direction
+    profit
+    last_price
+  )a
+end

--- a/lib/ex_huobi/futures/rest/account.ex
+++ b/lib/ex_huobi/futures/rest/account.ex
@@ -3,6 +3,7 @@ defmodule ExHuobi.Futures.Rest.Account do
 
   alias ExHuobi.Futures.AccountInfo
   alias ExHuobi.Futures.Rest.Handler
+  alias ExHuobi.Futures.Position
   alias ExHuobi.Rest.HTTPClient
   alias ExHuobi.Util
 
@@ -30,6 +31,22 @@ defmodule ExHuobi.Futures.Rest.Account do
       %{"symbol" => instrument_id},
       config
     )
+    |> Handler.parse_response()
+    |> Util.transform_response_data(AccountInfo)
+  end
+
+  @spec get_all_positions(config) :: {:error, any} | {:ok, any}
+  def get_all_positions(config) do
+    @hbdm_host
+    |> HTTPClient.post("/api/v1/contract_position_info", %{}, config)
+    |> Handler.parse_response()
+    |> Util.transform_response_data(Position)
+  end
+
+  @spec get_all_accounts(config) :: {:error, any} | {:ok, any}
+  def get_all_accounts(config) do
+    @hbdm_host
+    |> HTTPClient.post("/api/v1/contract_account_info", %{}, config)
     |> Handler.parse_response()
     |> Util.transform_response_data(AccountInfo)
   end

--- a/lib/ex_huobi/margin/balance.ex
+++ b/lib/ex_huobi/margin/balance.ex
@@ -1,0 +1,12 @@
+defmodule ExHuobi.Margin.Balance do
+  @moduledoc false
+
+  @type t :: %__MODULE__{}
+
+  defstruct ~w(
+    id
+    state
+    type
+    list
+  )a
+end

--- a/lib/ex_huobi/margin/rest/account.ex
+++ b/lib/ex_huobi/margin/rest/account.ex
@@ -2,6 +2,7 @@ defmodule ExHuobi.Margin.Rest.Account do
   @moduledoc false
 
   alias ExHuobi.Margin.Account, as: AccountModel
+  alias ExHuobi.Margin.Balance
   alias ExHuobi.Margin.Rest.Handler
   alias ExHuobi.Rest.HTTPClient
   alias ExHuobi.Util
@@ -22,5 +23,13 @@ defmodule ExHuobi.Margin.Rest.Account do
     |> HTTPClient.get("/v1/account/accounts", config)
     |> Handler.parse_response()
     |> Util.transform_response_data(AccountModel)
+  end
+
+  @spec get_balances(integer, config) :: response
+  def get_balances(account_id, config) do
+    @margin_endpoint
+    |> HTTPClient.get("/v1/account/accounts/#{account_id}/balance", config)
+    |> Handler.parse_response()
+    |> Util.transform_response_data(Balance)
   end
 end

--- a/lib/ex_huobi/swap/rest/account.ex
+++ b/lib/ex_huobi/swap/rest/account.ex
@@ -30,4 +30,18 @@ defmodule ExHuobi.Swap.Rest.Account do
     )
     |> Handler.parse_response()
   end
+
+  @spec get_all_positions(config) :: {:error, any} | {:ok, any}
+  def get_all_positions(config) do
+    @hbdm_host
+    |> HTTPClient.post("/swap-api/v1/swap_position_info", %{}, config)
+    |> Handler.parse_response()
+  end
+
+  @spec get_all_accounts(config) :: {:error, any} | {:ok, any}
+  def get_all_accounts(config) do
+    @hbdm_host
+    |> HTTPClient.post("/swap-api/v1/swap_account_info", %{}, config)
+    |> Handler.parse_response()
+  end
 end

--- a/lib/ex_huobi/usdt_swap/rest/account.ex
+++ b/lib/ex_huobi/usdt_swap/rest/account.ex
@@ -30,4 +30,26 @@ defmodule ExHuobi.UsdtSwap.Rest.Account do
     )
     |> Handler.parse_response()
   end
+
+  @spec get_all_positions(config) :: {:error, any} | {:ok, any}
+  def get_all_positions(config) do
+    @hbdm_host
+    |> HTTPClient.post(
+         "/linear-swap-api/v1/swap_cross_position_info",
+         %{},
+         config
+       )
+    |> Handler.parse_response()
+  end
+
+  @spec get_all_accounts(config) :: {:error, any} | {:ok, any}
+  def get_all_accounts(config) do
+    @hbdm_host
+    |> HTTPClient.post(
+         "/linear-swap-api/v1/swap_cross_account_info",
+         %{},
+         config
+       )
+    |> Handler.parse_response()
+  end
 end


### PR DESCRIPTION
I added some new apis:
- Spot/Margin account
https://huobiapi.github.io/docs/spot/v1/en/#get-account-balance-of-a-specific-account
- Future position
https://huobiapi.github.io/docs/dm/v1/en/#query-user-s-position-information
- Swap balance and position
https://huobiapi.github.io/docs/coin_margined_swap/v1/en/#query-user-s-account-information
https://huobiapi.github.io/docs/coin_margined_swap/v1/en/#query-user-s-position-information
- USDT swap balance and position
https://huobiapi.github.io/docs/usdt_swap/v1/en/#cross-query-user-39-s-account-information
https://huobiapi.github.io/docs/usdt_swap/v1/en/#cross-query-user-39-s-position-information